### PR TITLE
Add global installation option

### DIFF
--- a/CommandLineOptions.cs
+++ b/CommandLineOptions.cs
@@ -21,6 +21,7 @@ abstract record Command
         public bool Force { get; init; } = false;
         public bool Self { get; init; } = false;
         public bool Prereqs { get; init; } = false;
+        public bool Global { get; init; } = false;
     }
 
     public sealed record UpdateOptions : Command
@@ -48,6 +49,7 @@ sealed record class CommandLineOptions(Command Command)
                 bool force = default;
                 bool self = default;
                 bool prereqs = default;
+                bool global = default;
                 syntax.DefineOption("v|verbose", ref verbose, "Print debugging messages to the console.");
                 syntax.DefineOption(
                     "c|channel",
@@ -63,13 +65,15 @@ sealed record class CommandLineOptions(Command Command)
                 syntax.DefineOption("f|force", ref force, "Force install the given SDK, even if already installed");
                 syntax.DefineOption("self", ref self, "Install dnvm itself into the target location");
                 syntax.DefineOption("prereqs", ref prereqs, "Print prereqs for dotnet on Ubuntu");
+                syntax.DefineOption("g|global", ref global, "Install to the global location");
                 command = new Command.InstallOptions
                 {
                     Channel = channel,
                     Verbose = verbose,
                     Force = force,
                     Self = self,
-                    Prereqs = prereqs
+                    Prereqs = prereqs,
+                    Global = global
                 };
             }
 

--- a/Install.cs
+++ b/Install.cs
@@ -16,14 +16,7 @@ namespace Dnvm;
 
 sealed class Install
 {
-    private readonly string _installDir;
-    private readonly string _manifestPath;
-
-    private readonly Logger _logger;
-    private readonly Command.InstallOptions _options;
-
     private static string s_defaultInstallDir = Path.Combine(Environment.GetFolderPath(SpecialFolder.UserProfile), ".dotnet");
-
     private static string s_globalInstallDir =
         Utilities.CurrentRID.OS == OSPlatform.Windows ?
             Path.Combine(Environment.GetFolderPath(SpecialFolder.ProgramFiles), "dotnet")
@@ -31,6 +24,12 @@ sealed class Install
             "/usr/local/share/dotnet" // MacOS no longer lets anyone mess with /usr/share, even as root
         :
             "/usr/share/dotnet";
+
+    private readonly string _installDir;
+    private readonly string _manifestPath;
+
+    private readonly Logger _logger;
+    private readonly Command.InstallOptions _options;
 
     private async Task<int> LinuxAddToPath(string pathToAdd)
     {
@@ -60,7 +59,7 @@ sealed class Install
                 _logger.Error("Unable to write path to /etc/profile, attempting to write to local environment");
             }
         }
-        return await UnixAddToLocalPath(pathToAdd);
+        return await UnixAddToPathInShellFiles(pathToAdd);
     }
 
     private async Task<int> MacAddToPath(string pathToAdd)
@@ -81,7 +80,7 @@ sealed class Install
                 _logger.Error("Unable to write path to /etc/paths.d/dotnet, attempting to write to local environment");
             }
         }
-        return await UnixAddToLocalPath(pathToAdd);
+        return await UnixAddToPathInShellFiles(pathToAdd);
     }
 
     public Install(Logger logger, Command.InstallOptions options)
@@ -349,7 +348,7 @@ esac
         return 0;
     }
 
-    private async Task<int> UnixAddToLocalPath(string pathToAdd)
+    private async Task<int> UnixAddToPathInShellFiles(string pathToAdd)
     {
         _logger.Info("Setting environment variables in shell files");
         string resolvedEnvPath = Path.Combine(pathToAdd, "env");

--- a/Install.cs
+++ b/Install.cs
@@ -343,7 +343,7 @@ esac
         var currentPathVar = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User);
         if (!(":" + currentPathVar + ":").Contains(_installDir))
         {
-            Environment.SetEnvironmentVariable("PATH", _installDir + ":" + currentPathVar, EnvironmentVariableTarget.User);
+            Environment.SetEnvironmentVariable("PATH", _installDir + ":" + currentPathVar, _options.Global ? EnvironmentVariableTarget.Machine : EnvironmentVariableTarget.User);
         }
         return 0;
     }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -19,7 +19,7 @@ static class Utilities
             throw new NotSupportedException("Current OS is not supported: " + RuntimeInformation.OSDescription);
     }
 
-    public static string ProcessPath = Environment.ProcessPath 
+    public static string ProcessPath = Environment.ProcessPath
         ?? throw new InvalidOperationException("Cannot find exe name");
 
     public static string ExeName = "dnvm" + (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -52,11 +52,10 @@ internal readonly record struct RID(
             Architecture.X64 => "x64",
             _ => throw new NotSupportedException("Unsupported architecture")
         };
-        string libc = Libc switch
+        return Libc switch
         {
-            Libc.Default => "",
-            Libc.Musl => "musl"
+            Libc.Default => string.Join("-", os, arch),
+            Libc.Musl => string.Join('-', os, arch, "musl")
         };
-        return string.Join('-', os, arch, libc);
     }
 }


### PR DESCRIPTION
Adds an option to install dotnet at the global location (C:\Program Files\dotnet on Windows, /usr/local/share/dotnet on Mac, /usr/share/dotnet on Linux), and updates the global paths for each OS.

Have only been able to test on Mac so far, but seems to work there.