### PR TITLE
Update releases URL and add test

### DIFF
--- a/src/Update.cs
+++ b/src/Update.cs
@@ -16,6 +16,8 @@ public sealed partial class Update
     private readonly Logger _logger;
     private readonly Command.UpdateOptions _options;
 
+    public const string DefaultReleasesUrl = "https://commentout.com/dnvm/releases.json";
+
     public Update(Logger logger, Command.UpdateOptions options)
     {
         _logger = logger;
@@ -74,7 +76,7 @@ public sealed partial class Update
 
     public async Task<string> GetReleaseLink()
     {
-        var releasesUrl = _options.ReleasesUrl ?? "https://agocke.github.io/dnvm/releases.json";
+        var releasesUrl = _options.ReleasesUrl ?? DefaultReleasesUrl;
         string releasesJson = await Program.DefaultClient.GetStringAsync(releasesUrl);
         _logger.Info("Releases JSON: " + releasesJson);
         var releases = JsonSerializer.Deserialize<Releases>(releasesJson);

--- a/test/UnitTests/UpdateTests.cs
+++ b/test/UnitTests/UpdateTests.cs
@@ -1,4 +1,5 @@
 
+using Serde.Json;
 using Xunit;
 
 namespace Dnvm.Test;
@@ -14,5 +15,15 @@ public class UpdateTests
         });
         var link = await update.GetReleaseLink();
         Assert.Equal($"{mockServer.PrefixString}dnvm/dnvm.{Utilities.ZipSuffix}", link);
+    }
+
+    // N.B. Hits the public releases endpoint. Could fail if the website is down or internet
+    // connectivity is disrupted.
+    [Fact]
+    public async Task ReleasesEndpointIsUp()
+    {
+        var responseString = await Program.DefaultClient.GetStringAsync(Update.DefaultReleasesUrl);
+        var releases = JsonSerializer.Deserialize<Update.Releases>(responseString);
+        Assert.NotEmpty(releases.LatestVersion.Version);
     }
 }


### PR DESCRIPTION
Apparently the GitHub Pages redirect will go from https->http if you use the <username>.github.io URL instead of the custom domain that's associated with the repo. This breaks dnvm because it doesn't follow https->http redirects.