### PR TITLE
Fix binary validation

### DIFF
--- a/src/CommandLine/ArgumentSyntax.cs
+++ b/src/CommandLine/ArgumentSyntax.cs
@@ -53,7 +53,7 @@ namespace Internal.CommandLine
             if (HandleHelp && IsHelpRequested())
             {
                 var helpText = GetHelpText();
-                Console.Error.Write(helpText);
+                Console.Out.Write(helpText);
                 Environment.Exit(0);
             }
 

--- a/src/Update.cs
+++ b/src/Update.cs
@@ -126,9 +126,18 @@ public sealed partial class Update
         {
             await testProc.WaitForExitAsync();
             var output = await ps.StandardOutput.ReadToEndAsync();
-            if (ps.ExitCode != 0 || !output.Contains("usage: "))
+            string error = await ps.StandardError.ReadToEndAsync();
+            const string usageString = "usage: ";
+            if (ps.ExitCode != 0)
             {
-                _logger.Error("Could not run downloaded dnvm");
+                _logger.Error("Could not run downloaded dnvm:");
+                _logger.Error(error);
+                return false;
+            }
+            else if (!output.Contains(usageString))
+            {
+                _logger.Error($"Downloaded dnvm did not contain \"{usageString}\": ");
+                _logger.Log(output);
                 return false;
             }
             return true;

--- a/test/PublishTests/PublishTests.csproj
+++ b/test/PublishTests/PublishTests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../src/Dnvm/dnvm.csproj" />
     <ProjectReference Include="..\Shared\Dnvm.Test.Shared.csproj" />
   </ItemGroup>
 

--- a/test/PublishTests/UpdateTests.cs
+++ b/test/PublishTests/UpdateTests.cs
@@ -36,4 +36,14 @@ public class UpdateTests
         Assert.Contains("Hello from dnvm test", proc.StandardOutput.ReadToEnd());
         Assert.Equal(0, proc.ExitCode);
     }
+
+    [Fact]
+    public async Task ValidateBinary()
+    {
+        using var tmpDir = TestUtils.CreateTempDirectory();
+        var dnvmTmpPath = tmpDir.CopyFile(DnvmExe);
+        var logger = new Logger();
+        var update = new Update(logger, new Command.UpdateOptions());
+        Assert.True(await update.ValidateBinary(dnvmTmpPath));
+    }
 }


### PR DESCRIPTION
The update command tries to validate the downloaded dnvm binary to ensure that it can do basic things. One thing it checks is whether it can print a help message which contains the 'usage: ' string. However, previously dnvm printed the usage message to stderr instead of stdout, so the validation failed. The handler has been updated to print help to stdout iff it's requested.