### PR TITLE
Set DOTNET_ROOT in env.sh

### DIFF
--- a/src/env.sh
+++ b/src/env.sh
@@ -8,3 +8,6 @@ case ":${PATH}:" in
         export PATH="{install_loc}:$PATH"
         ;;
 esac
+if [ -z "$DOTNET_ROOT" ]; then
+    export DOTNET_ROOT="{install_loc}"
+fi


### PR DESCRIPTION
When installing dotnet locally (i.e., not in the hardcoded global install path) the apphost will not be able to find the dotnet runtime unless DOTNET_ROOT is set. This sets DOTNET_ROOT when installing to a local path to ensure that apphosts will work.