### PR TITLE
Make gh-pages publish on Release publish

### DIFF
--- a/.github/workflows/makeRelease.yml
+++ b/.github/workflows/makeRelease.yml
@@ -59,22 +59,3 @@ jobs:
           draft: true
           files:
             dnvm-*/dnvm-*
-  gh-pages:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 7.0.100-preview.4.22252.9
-      - name: Build web content
-        run: dotnet run --project tools/UpdateVersionJson/UpdateVersionJson.csproj
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./artifacts/gh-pages

--- a/.github/workflows/webUpdate.yml
+++ b/.github/workflows/webUpdate.yml
@@ -1,0 +1,26 @@
+
+name: Web Update
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 7.0.100-preview.4.22252.9
+      - name: Build web content
+        run: dotnet run --project tools/UpdateVersionJson/UpdateVersionJson.csproj
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./artifacts/gh-pages


### PR DESCRIPTION
Instead of publishing gh-pages on creation of the tag, publishing gh-pages will happen when the release is actually published.