### PR TITLE
Go back to strings for feed construction

### DIFF
--- a/src/CommandLineOptions.cs
+++ b/src/CommandLineOptions.cs
@@ -59,6 +59,7 @@ sealed record class CommandLineOptions(Command Command)
                 bool self = default;
                 bool prereqs = default;
                 bool global = default;
+                string? feedUrl = null;
                 syntax.DefineOption("v|verbose", ref verbose, "Print debugging messages to the console.");
                 syntax.DefineOption(
                     "c|channel",
@@ -75,6 +76,7 @@ sealed record class CommandLineOptions(Command Command)
                 syntax.DefineOption("self", ref self, "Install dnvm itself into the target location");
                 syntax.DefineOption("prereqs", ref prereqs, "Print prereqs for dotnet on Ubuntu");
                 syntax.DefineOption("g|global", ref global, "Install to the global location");
+                syntax.DefineOption("feed-url", ref feedUrl, "Set the feed URL to download the SDK from.");
                 command = new Command.InstallOptions
                 {
                     Channel = channel,
@@ -83,7 +85,7 @@ sealed record class CommandLineOptions(Command Command)
                     Self = self,
                     Prereqs = prereqs,
                     Global = global,
-
+                    FeedUrl = feedUrl,
                 };
             }
 

--- a/src/Install.cs
+++ b/src/Install.cs
@@ -83,7 +83,11 @@ public sealed class Install
                 "https://dotnetbuilds.azureedge.net/public"
             };
 
-        var feed = new Uri(feeds[0]);
+        var feed = feeds[0];
+        if (feed[^1] == '/')
+        {
+            feed = feed[..^1];
+        }
 
         RID rid = Utilities.CurrentRID;
 
@@ -204,13 +208,13 @@ public sealed class Install
 
     private static readonly HttpClient s_noRedirectClient = new HttpClient(new HttpClientHandler() { AllowAutoRedirect = false });
 
-    static Uri ConstructDownloadLink(Uri feed, string latestVersion, string archiveName)
+    static string ConstructDownloadLink(string feed, string latestVersion, string archiveName)
     {
-        return new Uri(feed, $"/Sdk/{latestVersion}/{archiveName}");
+        return $"{feed}/Sdk/{latestVersion}/{archiveName}";
     }
 
     private async Task<string?> GetLatestVersion(
-        Uri feed,
+        string feed,
         Channel channel,
         RID rid,
         string suffix)
@@ -219,7 +223,7 @@ public sealed class Install
         // The dotnet service provides an endpoint for fetching the latest LTS and Current versions
         if (channel != Channel.Preview)
         {
-            var versionFileUrl = new Uri(feed, $"/Sdk/{channel}/latest.version");
+            var versionFileUrl = $"{feed}/Sdk/{channel}/latest.version";
             _logger.Info("Fetching latest version from URL " + versionFileUrl);
             latestVersion = await Program.DefaultClient.GetStringAsync(versionFileUrl);
         }


### PR DESCRIPTION
The dotnet feeds include extra entries in the query string, which isn't supported using Uri relative path construction.