### PR TITLE
Fix arch fetching

### DIFF
--- a/src/Update.cs
+++ b/src/Update.cs
@@ -80,7 +80,10 @@ public sealed partial class Update
         string releasesJson = await Program.DefaultClient.GetStringAsync(releasesUrl);
         _logger.Info("Releases JSON: " + releasesJson);
         var releases = JsonSerializer.Deserialize<Releases>(releasesJson);
-        var rid = Utilities.CurrentRID.ToString();
+        // Dnvm doesn't currently publish ARM64 binaries for any platform
+        var rid = (Utilities.CurrentRID with {
+            Arch = Architecture.X64
+        }).ToString();
         var artifactDownloadLink = releases.LatestVersion.Artifacts[rid];
         _logger.Info("Artifact download link: " + artifactDownloadLink);
         return artifactDownloadLink;

--- a/src/Utilities.cs
+++ b/src/Utilities.cs
@@ -16,7 +16,7 @@ public static class Utilities
 
     public static readonly RID CurrentRID = new RID(
         GetCurrentOSPlatform(),
-        RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? Architecture.X64 : RuntimeInformation.ProcessArchitecture,
+        RuntimeInformation.ProcessArchitecture,
         RuntimeInformation.RuntimeIdentifier.Contains("musl") ? Libc.Musl : Libc.Default);
 
     private static OSPlatform GetCurrentOSPlatform()


### PR DESCRIPTION
I previously changed the arch in CurrentRID to be
x64 if the current platform is OSX, but that accidentally changed the SDK install to download only x64 SDks, when ARM64 is needed.