### PR TITLE
Use net8 ILC on Mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 7.0.100-preview.4.22252.9
+        dotnet-version: 7.0.100
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/makeRelease.yml
+++ b/.github/workflows/makeRelease.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 7.0.100-preview.4.22252.9
+        dotnet-version: 7.0.100
     - name: Restore local tools
       run: dotnet tool restore
     - name: Publish Windows

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 7.0.100-preview.4.22252.9
+        dotnet-version: 7.0.100
     - name: Restore local tools
       run: dotnet tool restore
     - name: Publish Windows

--- a/.github/workflows/webUpdate.yml
+++ b/.github/workflows/webUpdate.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 7.0.100-preview.4.22252.9
+          dotnet-version: 7.0.100
       - name: Build web content
         run: dotnet run --project tools/UpdateVersionJson/UpdateVersionJson.csproj
       - name: Deploy to gh-pages

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/publish.sh
+++ b/publish.sh
@@ -8,13 +8,20 @@ cd "$(dirname "$0")"
 dotnet tool restore
 
 version=$(dotnet gitversion /showvariable semver)
-
-# On osx we always use x64 for the moment as NativeAOT doesn't support osx-arm64
 if [[ $(uname) == 'Darwin' ]]; then
-    rid='osx-x64'
+    osname='osx'
 else
-    rid='linux-x64'
+    osname='linux'
 fi
+
+name=$(uname -m)
+if [[ $name == 'arm64' || $name == 'aarch64' ]]; then
+    arch='arm64'
+else
+    arch='x64'
+fi
+
+rid=$osname-$arch
 
 dotnet publish --sc -r $rid -c Release src/dnvm.csproj
 tar -C ./artifacts/bin/dnvm/Release/net7.0/$rid/publish/ -cvzf ./artifacts/dnvm-$version-$rid.tar.gz dnvm

--- a/src/dnvm.csproj
+++ b/src/dnvm.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <StripSymbols>true</StripSymbols>
     <InvariantGlobalization>true</InvariantGlobalization>
     <PublishAot>true</PublishAot>
     <DisableUnsupportedError>true</DisableUnsupportedError>

--- a/src/dnvm.csproj
+++ b/src/dnvm.csproj
@@ -4,16 +4,20 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <IlcHostArch>x64</IlcHostArch>
     <StripSymbols>true</StripSymbols>
     <InvariantGlobalization>true</InvariantGlobalization>
-    <IlcOptimizationPreference>size</IlcOptimizationPreference>
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <LangVersion>preview</LangVersion>
+    <PublishAot>true</PublishAot>
+    <DisableUnsupportedError>true</DisableUnsupportedError>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-x64'">
-    <CustomLinkerArg Include="-target x86_64-apple-darwin-macho" />
+  <ItemGroup Condition="$([MSBuild]::IsOsPlatform('OSX'))">
+    <KnownILCompilerPack Remove="Microsoft.DotNet.ILCompiler" />
+    <KnownILCompilerPack Include="Microsoft.DotNet.ILCompiler"
+                          TargetFramework="net7.0"
+                          ILCompilerPackNamePattern="runtime.**RID**.Microsoft.DotNet.ILCompiler"
+                          ILCompilerPackVersion="8.0.0-alpha.1.22559.2"
+                          ILCompilerRuntimeIdentifiers="linux-x64;linux-arm64;win-x64;win-arm64;osx-x64;osx-arm64;linux-musl-x64;linux-musl-arm64"
+                          />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,10 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
-    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-preview.5.22301.12" />
-    <PackageReference Include="runtime.osx-x64.Microsoft.DotNet.ILCompiler" Version="7.0.0-preview.5.22301.12" />
-
-    <PackageReference Include="Serde" Version="0.4.0" />
+    <PackageReference Include="Serde" Version="0.4.3" />
     <PackageReference Include="StaticCs" Version="0.2.0" />
   </ItemGroup>
 

--- a/test/PublishTests/PublishTests.csproj
+++ b/test/PublishTests/PublishTests.csproj
@@ -6,14 +6,10 @@
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <Rid>$(NETCoreSdkPortableRuntimeIdentifier)</Rid>
-    <!-- NativeAOT currently doesn't support osx-arm64 -->
-    <Rid Condition="'$(Rid)' == 'osx-arm64'">osx-x64</Rid>
     <DnvmPath>$(ArtifactsPath)/bin/dnvm/Release/$(TargetFramework)/$(Rid)/publish/dnvm$(ExeSuffix)</DnvmPath>
   </PropertyGroup>
 

--- a/test/Shared/Dnvm.Test.Shared.csproj
+++ b/test/Shared/Dnvm.Test.Shared.csproj
@@ -8,8 +8,6 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -6,8 +6,6 @@
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Mac is not supported on .NET 7, but we were using unsupported package builds. It will be supported in net8, so upgrading to net8 packages keeps us up to date and allows targeting arm64, which didn't even have preview packages before.