### PR TITLE
Grab releases info from official index

### DIFF
--- a/src/CommandLine/ArgumentSyntax_Definers.cs
+++ b/src/CommandLine/ArgumentSyntax_Definers.cs
@@ -88,9 +88,9 @@ namespace Internal.CommandLine
             return option;
         }
 
-        public Argument<string?> DefineOption(string name, ref string? value, string help)
+        public Argument<string?> DefineOption(string name, ref string value, string help)
         {
-            return DefineOption(name, ref value, s_stringParser, help);
+            return DefineOption(name, ref value, s_stringParser, help)!;
         }
 
         public Argument<bool> DefineOption(string name, ref bool value, string help)

--- a/src/CommandLineOptions.cs
+++ b/src/CommandLineOptions.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Diagnostics;
 using Internal.CommandLine;
 
 namespace Dnvm;
@@ -10,15 +11,15 @@ public abstract record Command
     public sealed record InstallOptions : Command
     {
         public required Channel Channel { get; init; }
+        /// <summary>
+        /// URL to the dotnet feed containing the releases index and download artifacts.
+        /// </summary>
+        public required string FeedUrl { get; init; }
         public bool Verbose { get; init; } = false;
         public bool Force { get; init; } = false;
         public bool Self { get; init; } = false;
         public bool Prereqs { get; init; } = false;
         public bool Global { get; init; } = false;
-        /// <summary>
-        /// Set the URL to the dotnet feed to install from.
-        /// </summary>
-        public string? FeedUrl { get; init; } = null;
         /// <summary>
         /// Path to install to.
         /// </summary>
@@ -33,9 +34,9 @@ public abstract record Command
 
     public sealed record UpdateOptions : Command
     {
+        public required string FeedUrl { get; init; }
         public bool Verbose { get; init; } = false;
         public bool Self { get; init; } = false;
-        public string? ReleasesUrl { get; init; } = null;
     }
 }
 
@@ -58,13 +59,13 @@ sealed record class CommandLineOptions(Command Command)
                 bool self = default;
                 bool prereqs = default;
                 bool global = default;
-                string? feedUrl = null;
+                string? feedUrl = DefaultConfig.FeedUrl;
                 syntax.DefineOption("v|verbose", ref verbose, "Print debugging messages to the console.");
                 syntax.DefineOption("f|force", ref force, "Force install the given SDK, even if already installed");
                 syntax.DefineOption("g|global", ref global, "Install to the global location");
                 syntax.DefineOption("self", ref self, "Install dnvm itself into the target location");
                 syntax.DefineOption("prereqs", ref prereqs, "Print prereqs for dotnet on Ubuntu");
-                syntax.DefineOption("feed-url", ref feedUrl, "Set the feed URL to download the SDK from.");
+                syntax.DefineOption("feed-url", ref feedUrl, $"Set the feed URL to download the SDK from. Default is {feedUrl}");
                 syntax.DefineParameter("channel", ref channel, c =>
                 {
                     if (Enum.TryParse<Channel>(c, ignoreCase: true, out var result))
@@ -94,16 +95,16 @@ sealed record class CommandLineOptions(Command Command)
             {
                 bool self = default;
                 bool verbose = default;
-                string? releasesUrl = default;
+                string feedUrl = DefaultConfig.FeedUrl;
                 syntax.DefineOption("self", ref self, "Update dnvm itself in the current location");
                 syntax.DefineOption("v|verbose", ref verbose, "Print debugging messages to the console.");
-                syntax.DefineOption("releases-url", ref releasesUrl, "Url to fetch info for location of latest releases.");
+                syntax.DefineOption("feed-url", ref feedUrl, $"Set the feed URL to download the SDK from. Default is {feedUrl}");
 
                 command = new Command.UpdateOptions
                 {
                     Self = self,
                     Verbose = verbose,
-                    ReleasesUrl = releasesUrl
+                    FeedUrl = feedUrl
                 };
             }
         });

--- a/src/DefaultConfig.cs
+++ b/src/DefaultConfig.cs
@@ -1,0 +1,17 @@
+
+using System.IO;
+using System.Runtime.InteropServices;
+using static System.Environment;
+
+namespace Dnvm;
+
+public static class DefaultConfig
+{
+    public const string FeedUrl = "https://dotnetcli.azureedge.net/dotnet";
+
+    internal static readonly string InstallDir = Path.Combine(GetFolderPath(SpecialFolder.LocalApplicationData, SpecialFolderOption.DoNotVerify), "dnvm");
+    internal static readonly string GlobalInstallDir =
+        Utilities.CurrentRID.OS == OSPlatform.Windows ? Path.Combine(GetFolderPath(SpecialFolder.ProgramFiles), "dotnet")
+        : Utilities.CurrentRID.OS == OSPlatform.OSX ? "/usr/local/share/dotnet" // MacOS no longer lets anyone mess with /usr/share, even as root
+        : "/usr/share/dotnet";
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -7,7 +7,7 @@ namespace Dnvm;
 
 public static class Program
 {
-    public static readonly HttpClient DefaultClient = new HttpClient();
+    public static readonly HttpClient HttpClient = new();
 
     static Task<int> Main(string[] args)
     {

--- a/src/Update.cs
+++ b/src/Update.cs
@@ -76,8 +76,8 @@ public sealed partial class Update
 
     public async Task<string> GetReleaseLink()
     {
-        var releasesUrl = _options.ReleasesUrl ?? DefaultReleasesUrl;
-        string releasesJson = await Program.DefaultClient.GetStringAsync(releasesUrl);
+        var releasesUrl = _options.FeedUrl ?? DefaultReleasesUrl;
+        string releasesJson = await Program.HttpClient.GetStringAsync(releasesUrl);
         _logger.Info("Releases JSON: " + releasesJson);
         var releases = JsonSerializer.Deserialize<Releases>(releasesJson);
         // Dnvm doesn't currently publish ARM64 binaries for any platform
@@ -100,7 +100,7 @@ public sealed partial class Update
             64 * 1024 /* 64kB */,
             FileOptions.WriteThrough))
         {
-            using var archiveHttpStream = await Program.DefaultClient.GetStreamAsync(uri);
+            using var archiveHttpStream = await Program.HttpClient.GetStreamAsync(uri);
             await archiveHttpStream.CopyToAsync(tempFile);
             await tempFile.FlushAsync();
         }

--- a/src/VersionInfo.cs
+++ b/src/VersionInfo.cs
@@ -1,0 +1,66 @@
+
+using System;
+using System.Collections.Immutable;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Xml.Schema;
+using Semver;
+using Serde;
+using Serde.Json;
+
+namespace Dnvm;
+
+public static class VersionInfoClient
+{
+    public const string ReleasesUrlSuffix = "/release-metadata/releases-index.json";
+    public async static Task<DotnetReleasesIndex> FetchLatestIndex(string feed, string urlSuffix = ReleasesUrlSuffix)
+    {
+        var response = await Program.HttpClient.GetStringAsync(feed + urlSuffix);
+        return JsonSerializer.Deserialize<DotnetReleasesIndex>(response);
+    }
+
+    public static DotnetReleasesIndex.Release? GetLatestReleaseForChannel(DotnetReleasesIndex index, Channel c)
+    {
+        (DotnetReleasesIndex.Release Release, SemVersion Version)? latestRelease = null;
+        foreach (var release in index.Releases)
+        {
+            var supportPhase = release.SupportPhase.ToLowerInvariant();
+            var releaseType = release.ReleaseType.ToLowerInvariant();
+            if (!SemVersion.TryParse(release.LatestRelease, SemVersionStyles.Strict, out var releaseVersion))
+            {
+                continue;
+            }
+            switch (c)
+            {
+                case Channel.Latest when supportPhase is "active":
+                case Channel.Lts when releaseType is "lts":
+                case Channel.Preview when supportPhase is "active" or "preview":
+                    if (latestRelease is not { } latest ||
+                        SemVersion.ComparePrecedence(releaseVersion, latest.Version) > 0)
+                    {
+                        latestRelease = (release, releaseVersion);
+                    }
+                    break;
+            }
+        }
+        return latestRelease?.Release;
+    }
+}
+
+[GenerateSerde]
+public partial record DotnetReleasesIndex
+{
+    [SerdeMemberOptions(Rename = "releases-index")]
+    public required ImmutableArray<Release> Releases { get; init; }
+
+    [GenerateSerde]
+    [SerdeTypeOptions(MemberFormat = MemberFormat.KebabCase)]
+    public partial record Release
+    {
+        public required string ChannelVersion { get; init; }
+        public required string LatestRelease { get; init; }
+        public required string ReleaseType { get; init; }
+        public required string SupportPhase { get; init; }
+        public required string LatestSdk { get; init; }
+    }
+}

--- a/src/dnvm.csproj
+++ b/src/dnvm.csproj
@@ -15,12 +15,7 @@
 
   <ItemGroup Condition="$([MSBuild]::IsOsPlatform('OSX'))">
     <KnownILCompilerPack Remove="Microsoft.DotNet.ILCompiler" />
-    <KnownILCompilerPack Include="Microsoft.DotNet.ILCompiler"
-                          TargetFramework="net7.0"
-                          ILCompilerPackNamePattern="runtime.**RID**.Microsoft.DotNet.ILCompiler"
-                          ILCompilerPackVersion="8.0.0-alpha.1.22559.2"
-                          ILCompilerRuntimeIdentifiers="linux-x64;linux-arm64;win-x64;win-arm64;osx-x64;osx-arm64;linux-musl-x64;linux-musl-arm64"
-                          />
+    <KnownILCompilerPack Include="Microsoft.DotNet.ILCompiler" TargetFramework="net7.0" ILCompilerPackNamePattern="runtime.**RID**.Microsoft.DotNet.ILCompiler" ILCompilerPackVersion="8.0.0-alpha.1.22559.2" ILCompilerRuntimeIdentifiers="linux-x64;linux-arm64;win-x64;win-arm64;osx-x64;osx-arm64;linux-musl-x64;linux-musl-arm64" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,8 +23,9 @@
     <PackageReference Include="GitVersion.MSBuild" Version="5.10.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Semver" Version="2.2.0" />
 
-    <PackageReference Include="Serde" Version="0.4.5" />
+    <PackageReference Include="Serde" Version="0.4.6" />
     <PackageReference Include="StaticCs" Version="0.2.0" />
   </ItemGroup>
 

--- a/test/PublishTests/UpdateTests.cs
+++ b/test/PublishTests/UpdateTests.cs
@@ -19,7 +19,7 @@ public class UpdateTests
         using var mockServer = new MockServer();
         var proc = Process.Start(new ProcessStartInfo() {
             FileName = dnvmTmpPath,
-            Arguments = $"update --self -v --releases-url {mockServer.PrefixString}releases.json",
+            Arguments = $"update --self -v --feed-url {mockServer.PrefixString}releases.json",
             RedirectStandardOutput = true,
             RedirectStandardError = true,
         });
@@ -43,7 +43,7 @@ public class UpdateTests
         using var tmpDir = TestUtils.CreateTempDirectory();
         var dnvmTmpPath = tmpDir.CopyFile(DnvmExe);
         var logger = new Logger();
-        var update = new Update(logger, new Command.UpdateOptions());
+        var update = new Update(logger, new Command.UpdateOptions() { FeedUrl = DefaultConfig.FeedUrl });
         Assert.True(await update.ValidateBinary(dnvmTmpPath));
     }
 }

--- a/test/Shared/MockServer.cs
+++ b/test/Shared/MockServer.cs
@@ -1,6 +1,8 @@
 
 using System.Net;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Unicode;
 using static Dnvm.Utilities;
 
 namespace Dnvm.Test;
@@ -13,6 +15,20 @@ public sealed class MockServer : IDisposable
 
     public string PrefixString => $"http://localhost:{Port}/";
     private const string VersionString = "42.42.42";
+
+    public string ReleasesIndexJson { get; set; } = """
+{
+    "releases-index": [
+        {
+            "channel-version": "42.42",
+            "latest-release": "42.42.42",
+            "latest-sdk": "42.42.42",
+            "release-type" : "lts",
+            "support-phase": "active"
+        }
+    ]
+}
+""";
 
     public MockServer()
     {
@@ -51,11 +67,33 @@ public sealed class MockServer : IDisposable
 
     private Dictionary<string, Action<HttpListenerResponse>> UrlToHandler => new()
     {
+        ["/release-metadata/releases-index.json"] = GetReleasesIndexJson,
         ["/sdk/lts/latest.version"] = GetLatestVersionUrl,
         [$"/sdk/{VersionString}/dotnet-sdk-{VersionString}-{CurrentRID}.{ZipSuffix}"] = GetSdk,
         ["/releases.json"] = GetReleasesJson,
         [$"/dnvm/dnvm.{ZipSuffix}"] = GetDnvm,
     };
+
+    private void GetReleasesIndexJson(HttpListenerResponse response)
+    {
+        byte[] buffer;
+        if (ReleasesIndexJson is null)
+        {
+            buffer = Encoding.UTF8.GetBytes(nameof(ReleasesIndexJson) + " property must be set");
+            response.StatusCode = (int)HttpStatusCode.InternalServerError;
+        }
+        else
+        {
+            buffer = Encoding.UTF8.GetBytes(ReleasesIndexJson);
+            response.StatusCode = (int)HttpStatusCode.OK;
+        }
+        // Get a response stream and write the response to it.
+        response.ContentLength64 = buffer.Length;
+        var output = response.OutputStream;
+        output.Write(buffer, 0, buffer.Length);
+        // You must close the output stream.
+        output.Close();
+    }
 
     private static void GetLatestVersionUrl(HttpListenerResponse response)
     {

--- a/test/UnitTests/InstallTests.cs
+++ b/test/UnitTests/InstallTests.cs
@@ -7,12 +7,6 @@ namespace Dnvm.Test;
 
 public class InstallTests
 {
-    private readonly ITestOutputHelper _testOutput;
-    public InstallTests(ITestOutputHelper testOutput)
-    {
-        _testOutput = testOutput;
-    }
-
     [Fact]
     public async Task Install()
     {

--- a/test/UnitTests/UpdateTests.cs
+++ b/test/UnitTests/UpdateTests.cs
@@ -11,7 +11,7 @@ public class UpdateTests
     {
         using var mockServer = new MockServer();
         var update = new Dnvm.Update(new Logger(), new Command.UpdateOptions {
-            ReleasesUrl = $"http://localhost:{mockServer.Port}/releases.json"
+            FeedUrl = $"http://localhost:{mockServer.Port}/releases.json"
         });
         var link = await update.GetReleaseLink();
         Assert.Equal($"{mockServer.PrefixString}dnvm/dnvm.{Utilities.ZipSuffix}", link);
@@ -22,8 +22,7 @@ public class UpdateTests
     [Fact]
     public async Task ReleasesEndpointIsUp()
     {
-        var responseString = await Program.DefaultClient.GetStringAsync(Update.DefaultReleasesUrl);
-        var releases = JsonSerializer.Deserialize<Update.Releases>(responseString);
-        Assert.NotEmpty(releases.LatestVersion.Version);
+        var releasesIndex = await VersionInfoClient.FetchLatestIndex(DefaultConfig.FeedUrl);
+        Assert.NotEmpty(releasesIndex.Releases);
     }
 }


### PR DESCRIPTION
Dotnet publishes an official index that includes all current releases, including official preview releases. This can be used instead of hitting multiple REST endpoints.