### PR TITLE
Move SDK install to a dotnet subdir

### DIFF
--- a/src/CommandLineOptions.cs
+++ b/src/CommandLineOptions.cs
@@ -19,11 +19,11 @@ public abstract record Command
         public bool Force { get; init; } = false;
         public bool Self { get; init; } = false;
         public bool Prereqs { get; init; } = false;
-        public bool Global { get; init; } = false;
         /// <summary>
-        /// Path to install to.
+        /// Directory to place the dnvm exe.
         /// </summary>
-        public string? InstallPath { get; init; } = null;
+        public string? DnvmInstallPath { get; init; } = null;
+        public string? SdkInstallPath { get; init; } = null;
 
         /// <summary>
         /// When true, add dnvm update lines to the user's config files
@@ -58,11 +58,9 @@ sealed record class CommandLineOptions(Command Command)
                 bool force = default;
                 bool self = default;
                 bool prereqs = default;
-                bool global = default;
                 string? feedUrl = DefaultConfig.FeedUrl;
                 syntax.DefineOption("v|verbose", ref verbose, "Print debugging messages to the console.");
                 syntax.DefineOption("f|force", ref force, "Force install the given SDK, even if already installed");
-                syntax.DefineOption("g|global", ref global, "Install to the global location");
                 syntax.DefineOption("self", ref self, "Install dnvm itself into the target location");
                 syntax.DefineOption("prereqs", ref prereqs, "Print prereqs for dotnet on Ubuntu");
                 syntax.DefineOption("feed-url", ref feedUrl, $"Set the feed URL to download the SDK from. Default is {feedUrl}");
@@ -85,7 +83,6 @@ sealed record class CommandLineOptions(Command Command)
                     Force = force,
                     Self = self,
                     Prereqs = prereqs,
-                    Global = global,
                     FeedUrl = feedUrl,
                 };
             }

--- a/src/DefaultConfig.cs
+++ b/src/DefaultConfig.cs
@@ -1,6 +1,5 @@
 
 using System.IO;
-using System.Runtime.InteropServices;
 using static System.Environment;
 
 namespace Dnvm;
@@ -9,9 +8,7 @@ public static class DefaultConfig
 {
     public const string FeedUrl = "https://dotnetcli.azureedge.net/dotnet";
 
-    internal static readonly string InstallDir = Path.Combine(GetFolderPath(SpecialFolder.LocalApplicationData, SpecialFolderOption.DoNotVerify), "dnvm");
-    internal static readonly string GlobalInstallDir =
-        Utilities.CurrentRID.OS == OSPlatform.Windows ? Path.Combine(GetFolderPath(SpecialFolder.ProgramFiles), "dotnet")
-        : Utilities.CurrentRID.OS == OSPlatform.OSX ? "/usr/local/share/dotnet" // MacOS no longer lets anyone mess with /usr/share, even as root
-        : "/usr/share/dotnet";
+    public static readonly string InstallDir = Path.Combine(
+        GetFolderPath(SpecialFolder.LocalApplicationData, SpecialFolderOption.DoNotVerify),
+        "dnvm");
 }

--- a/test/UnitTests/InstallTests.cs
+++ b/test/UnitTests/InstallTests.cs
@@ -16,14 +16,15 @@ public class InstallTests
         {
             Channel = Channel.Lts,
             FeedUrl = server.PrefixString,
-            InstallPath = tempDir.Path,
+            DnvmInstallPath = tempDir.Path,
             UpdateUserEnvironment = false,
         };
         var logger = new Logger();
-        var task = new Install(logger, options).Handle();
+        var installCmd = new Install(logger, options);
+        var task = installCmd.Handle();
         Result retVal = await task;
         Assert.Equal(Result.Success, retVal);
-        var dotnetFile = Path.Combine(tempDir.Path, "dotnet");
+        var dotnetFile = Path.Combine(installCmd.SdkInstallDir, "dotnet");
         Assert.True(File.Exists(dotnetFile));
         Assert.Contains(Assets.ArchiveToken, File.ReadAllText(dotnetFile));
 
@@ -43,14 +44,15 @@ public class InstallTests
         {
             Channel = Channel.Lts,
             FeedUrl = server.PrefixString,
-            InstallPath = installPath,
+            DnvmInstallPath = installPath,
             UpdateUserEnvironment = false,
         };
         var logger = new Logger();
-        var task = new Install(logger, options).Handle();
+        var installCmd = new Install(logger, options);
+        var task = installCmd.Handle();
         Result retVal = await task;
         Assert.Equal(Result.Success, retVal);
-        var dotnetFile = Path.Combine(installPath, "dotnet");
+        var dotnetFile = Path.Combine(installCmd.SdkInstallDir, "dotnet");
         Assert.True(File.Exists(dotnetFile));
         Assert.Contains(Assets.ArchiveToken, File.ReadAllText(dotnetFile));
     }


### PR DESCRIPTION
Right now everything goes into the install path, wherver that may be (localappdata or .local/share as appropriate). This makes it hard to group files just by the SDK, vs what's installed by dnvm. Adding a subdirectory reduces confusion

Also disabled global install for now. It's not clear exactly what it should do and probably needs more design.